### PR TITLE
feat: Context and Header annotations

### DIFF
--- a/vaden/example/lib/src/auth_controllar.dart
+++ b/vaden/example/lib/src/auth_controllar.dart
@@ -1,3 +1,4 @@
+import 'package:example/src/auth_middleware.dart';
 import 'package:example/src/auth_service.dart';
 import 'package:vaden/vaden.dart';
 
@@ -39,5 +40,20 @@ class AuthControllar {
     @Body() Credentials credentials,
   ) async {
     return Response.ok(credentials);
+  }
+
+  @UseMiddleware([AuthMiddleware])
+  @Post('/sign-out')
+  Future<Response> signOut(@Context('user_id') String userId) async {
+    return Response.ok('Deslogando do usuário $userId!');
+  }
+
+  @Post('/refresh-token')
+  Future<Response> refreshToken(@Header('Authorization') String? token) async {
+    if (token == null) {
+      return Response.unauthorized('Token not found');
+    }
+
+    return Response.ok('Token recuperado do header: ${token.replaceFirst('Bearer ', '')}');
   }
 }

--- a/vaden/example/lib/src/auth_middleware.dart
+++ b/vaden/example/lib/src/auth_middleware.dart
@@ -1,0 +1,34 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:vaden/vaden.dart';
+
+@Component()
+class AuthMiddleware extends VadenMiddleware {
+  @override
+  FutureOr<Response> handler(Request request, Handler handler) {
+    final token = request.headers['Authorization']?.replaceFirst('Bearer ', '');
+
+    if (token == null) {
+      return Response.unauthorized('Token not found');
+    }
+
+    // Fake verify (simple decode)
+
+    final parts = token.split('.');
+
+    if (parts.length != 3) {
+      return Response.unauthorized('Invalid token');
+    }
+
+    final payloadB64 = base64Url.normalize(parts[1]);
+
+    final payload = jsonDecode(utf8.decode(base64Url.decode(payloadB64)));
+
+    final userId = payload['user_id'] as String;
+
+    final changed = request.change(context: {'user_id': userId});
+
+    return handler(changed);
+  }
+}

--- a/vaden/lib/src/annotations/annotation.dart
+++ b/vaden/lib/src/annotations/annotation.dart
@@ -85,3 +85,13 @@ class Param {
 class Body {
   const Body();
 }
+
+class Header {
+  final String name;
+  const Header(this.name);
+}
+
+class Context {
+  final String name;
+  const Context(this.name);
+}

--- a/vaden_class_scanner/lib/src/aggregating_vaden_builder.dart
+++ b/vaden_class_scanner/lib/src/aggregating_vaden_builder.dart
@@ -58,6 +58,8 @@ class AggregatingVadenBuilder implements Builder {
 
   final paramChecker = TypeChecker.fromRuntime(Param);
   final queryChecker = TypeChecker.fromRuntime(Query);
+  final headerChecker = TypeChecker.fromRuntime(Header);
+  final contextChecker = TypeChecker.fromRuntime(Context);
 
   @override
   Future<void> build(BuildStep buildStep) async {
@@ -487,6 +489,25 @@ paths['$apiPathResolver']['$routerMethod']['parameters']?.add({
 """);
           }
           paramCodeList.add("final ${parameter.name} = request.url.queryParameters['$qname'];");
+        } else if (headerChecker.hasAnnotationOf(parameter)) {
+          final hname = headerChecker.firstAnnotationOf(parameter)?.getField('name')?.toStringValue() ?? parameter.name;
+          if (api != null) {
+            bodyBuffer.writeln("""
+paths['$apiPathResolver']['$routerMethod']['parameters']?.add({
+  'name': '$hname',
+  'in': 'header',
+  'required': ${!_isNullable(parameter.type)},
+  'schema': {
+    'type': 'string',
+  },
+});
+""");
+          }
+          paramCodeList.add("final ${parameter.name} = request.headers['$hname'];");
+        } else if (contextChecker.hasAnnotationOf(parameter)) {
+          final cname = contextChecker.firstAnnotationOf(parameter)?.getField('name')?.toStringValue() ?? parameter.name;
+          final ctype = parameter.type.getDisplayString();
+          paramCodeList.add("final ${parameter.name} = request.context['$cname'] as $ctype;");
         } else {
           final paramType = parameter.type.getDisplayString();
           if (paramType == 'Request' || paramType == 'Request?') {


### PR DESCRIPTION
**O PR adiciona duas novas anotações para uso nas rotas, `@Context` e `@Header` para facilitar ao acesso de dados da request sem a necessidade de utilizar a variavel `Request` diretamente na rota.**

Exemplo do `@Header`, que recupera a chave `Authorization` do header da request, por se tratar de uma informação vinda do header, trata-se apenas do tipo `String?`:

```dart
@Post('/refresh-token')
Future<Response> refreshToken(@Header('Authorization') String? token) async {
  if (token == null) {
    return Response.unauthorized('Token not found');
  }

  return Response.ok('Token recuperado do header: ${token.replaceFirst('Bearer ', '')}');
}
```

Exemplo do `@Context`, que recupera a chave `user_id` do contexto da request, este valor foi adicionado no contexto através de um middleware que no exemplo abaixo faz o decode de um token jwt e retira a chave do payload, no caso do contexto pode ser passado qualquer tipo de variável, mas no exemplo a seguir eu utilizei de uma string também, mas é independente:

Exemplo de middleware

```dart
@Component()
class AuthMiddleware extends VadenMiddleware {
  @override
  FutureOr<Response> handler(Request request, Handler handler) {
    final token = request.headers['Authorization']?.replaceFirst('Bearer ', '');

    if (token == null) {
      return Response.unauthorized('Token not found');
    }

    // Fake verify (simple decode)

    final parts = token.split('.');

    if (parts.length != 3) {
      return Response.unauthorized('Invalid token');
    }

    final payloadB64 = base64Url.normalize(parts[1]);

    final payload = jsonDecode(utf8.decode(base64Url.decode(payloadB64)));

    final userId = payload['user_id'] as String;

    final changed = request.change(context: {'user_id': userId});

    return handler(changed);
  }
}
```

Exemplo da rota que utiliza do middleware recuperando a string anteriormente colocada no contexto

```dart
@UseMiddleware([AuthMiddleware])
@Post('/sign-out')
Future<Response> signOut(@Context('user_id') String userId) async {
  return Response.ok('Deslogando do usuário $userId!');
}
```