### PR TITLE
Update getting-started.md

### DIFF
--- a/doc/docs/Introduction/getting-started.md
+++ b/doc/docs/Introduction/getting-started.md
@@ -21,7 +21,7 @@ dart pub get
 
 ## 3. Run the Class Scanner with build_runner
 
-The **Class Scanner** iintroduces Java-inspired metaprogramming to Dart. Since this feature is integrated with build_runner, simply run the build or watch command during development:
+The **Class Scanner** introduces Java-inspired metaprogramming to Dart. Since this feature is integrated with build_runner, simply run the build or watch command during development:
 
 ```sh title="Terminal"
 dart run build_runner watch


### PR DESCRIPTION
doc: fix docs about how to run the project with build runing 

iintroduces -> introduces

### 📄 Descrição

Correção do texto da documentação de executar o projeto utilizando o build_runner

### 🔄 Mudanças Realizadas

Mudar iintroduces para introduces na seção 3 de executar o projeto .

### ✅ Checklist

- [X] Documentação foi atualizada (se necessário).

