### PR TITLE
[BUG FIX] Project Creation with Reseverd Keywords

### DIFF
--- a/vaden_generator/frontend/lib/domain/validators/project_validator.dart
+++ b/vaden_generator/frontend/lib/domain/validators/project_validator.dart
@@ -3,12 +3,31 @@ import 'package:lucid_validation/lucid_validation.dart';
 import '../entities/project.dart';
 
 class ProjectValidator extends LucidValidator<Project> {
+  // List of Dart reserved keywords and framework name
+  static final List<String> _reservedKeywords = [
+    'abstract', 'as', 'assert', 'async', 'await', 'break', 'case', 'catch',
+    'class', 'const', 'continue', 'covariant', 'default', 'deferred', 'do',
+    'dynamic', 'else', 'enum', 'export', 'extends', 'extension', 'external',
+    'factory', 'false', 'final', 'finally', 'for', 'Function', 'get', 'hide',
+    'if', 'implements', 'import', 'in', 'interface', 'is', 'late', 'library',
+    'mixin', 'new', 'null', 'on', 'operator', 'part', 'required', 'rethrow',
+    'return', 'set', 'show', 'static', 'super', 'switch', 'sync', 'this',
+    'throw', 'true', 'try', 'typedef', 'var', 'void', 'while', 'with', 'yield',
+    // Framework name
+    'vaden'
+  ];
+
   ProjectValidator() {
     ruleFor((p) => p.name, key: 'name') //
         .notEmpty(message: 'notEmpty')
         .minLength(3, message: 'minLength')
         .maxLength(50, message: 'maxLength')
-        .matchesPattern(r'^[a-z][a-z0-9_]*$', code: 'invalidName');
+        .matchesPattern(r'^[a-z][a-z0-9_]*$', code: 'invalidName')
+        .must(
+          (name) => !_reservedKeywords.contains(name.toLowerCase()),
+          'reservedKeyword',
+          'reservedKeyword'
+        );
 
     ruleFor((p) => p.description, key: 'description') //
         .notEmpty(message: 'notEmpty')

--- a/vaden_generator/frontend/lib/i18n/en_US.json
+++ b/vaden_generator/frontend/lib/i18n/en_US.json
@@ -24,5 +24,6 @@
   "maxLength": "Excessive number of characters",
   "minLength": "Insufficient number of characters",
   "notEmpty": "Cannot be empty",
-  "addDependencies": "Add dependencies"
+  "addDependencies": "Add dependencies",
+  "reservedKeyword": "The name cannot be a Dart reserved keyword or the framework name (Vaden)"
 }

--- a/vaden_generator/frontend/lib/i18n/es_ES.json
+++ b/vaden_generator/frontend/lib/i18n/es_ES.json
@@ -24,5 +24,6 @@
   "maxLength": "Número excesivo de caracteres",
   "minLength": "Número insuficiente de caracteres",
   "notEmpty": "No puede estar vacío",
-  "addDependencies": "Añadir dependencias"
+  "addDependencies": "Añadir dependencias",
+  "reservedKeyword": "El nombre no puede ser una palabra reservada de Dart o el nombre del framework (Vaden)"
 }

--- a/vaden_generator/frontend/lib/i18n/pt_BR.json
+++ b/vaden_generator/frontend/lib/i18n/pt_BR.json
@@ -24,5 +24,6 @@
   "maxLength": "Quantidade excessiva de caracteres",
   "minLength": "Quantidade de caracteres insuficiente",
   "notEmpty": "Não pode estar vazio",
-  "addDependencies": "Adicionar dependencias"
+  "addDependencies": "Adicionar dependencias",
+  "reservedKeyword": "O nome não pode ser uma palavra reservada do Dart ou o nome do framework (Vaden)"
 }


### PR DESCRIPTION
### 📄 Descrição

Adicionado erro de validaçāo no campo "Nome do projeto" ao usar palavras reservadas do Dart e/ou nome do Framwork (Vaden)

### 🔄 Mudanças Realizadas

- [x] Adcionado lista de palavras reservadas no ProjectValidation
- [x] Adicionado traduçōes ao erro, suportando os idiomas principais usados na pagina web

### ✅ Checklist

- [x] Testes foram adicionados ou atualizados.
- [x] Documentação foi atualizada (se necessário).
- [x] Revisão de código completa.

### 🔗 Issue Relacionada

Resolves #41 