### PR TITLE
[FRONT- DOC]  correção do efeito do background que permanecia preto quando fazia o scroll

### DIFF
--- a/doc/src/css/custom.css
+++ b/doc/src/css/custom.css
@@ -68,9 +68,10 @@
 .hero .hero__subtitle {
   text-shadow: none !important;
 }
-
+html,
 body {
   background-color: #000000 !important;
+  height: 100vh;
 }
 
 .footer,


### PR DESCRIPTION
### 📄 Descrição

Adicionar altura para tornar toda a pagina da documentação com fundo preto.
### 🔄 Mudanças Realizadas

Adicionar a tag html , antes da tag body , e colocando uma altura de 100hv de modo que o background cubra toda a area e nao somente a parte do scroll.

<img width="1421" alt="image" src="https://github.com/user-attachments/assets/71435fc1-e77b-480b-84ae-7f605c53a9dd" />

### ✅ Checklist

- [ ] Testes foram adicionados ou atualizados.
- [ ] Documentação foi atualizada (se necessário).
- [ ] Revisão de código completa.

### 🔗 Issue Relacionada


