### PR TITLE
[FIX] Vaden Security missing on pubspec.yaml and app_module.dart

### DIFF
--- a/vaden_generator/backend/lib/src/core/files/generators/initial_project.dart
+++ b/vaden_generator/backend/lib/src/core/files/generators/initial_project.dart
@@ -83,6 +83,7 @@ environment:
 
 dependencies:
   vaden: {{vaden}}
+  vaden_security: {{vaden_security}}
 
 dev_dependencies:
   build_runner: {{build_runner}}

--- a/vaden_generator/backend/lib/src/core/files/generators/initial_project.dart
+++ b/vaden_generator/backend/lib/src/core/files/generators/initial_project.dart
@@ -235,6 +235,7 @@ class AppConfiguration {
 ''';
 
 const _libConfigAppModuleContent = '''import 'package:vaden/vaden.dart';
+import 'package:vaden_security/vaden_security.dart';
 
 @VadenModule([VadenSecurity])
 class AppModule {}


### PR DESCRIPTION
### 📄 Descrição

Essa PR corrigi a falta da dependencia vaden_security no pubspec.yaml e sua importação no app_module.dart

### 🔄 Mudanças Realizadas

- [ ] Adcionado o vaden_security na geração do pubspec.yaml e app_module.dart.

### ✅ Checklist

- [x] Testes foram adicionados ou atualizados.
- [x] Documentação foi atualizada (se necessário).
- [x] Revisão de código completa.

### 🔗 Issue Relacionada

Resolves #85 