### PR TITLE
[FIX] Generate AppModule only when vaden_security is selected

### DIFF
--- a/vaden_generator/backend/assets/dependencies.json
+++ b/vaden_generator/backend/assets/dependencies.json
@@ -47,6 +47,13 @@
         "key": "cron",
         "tag": "SYSTEM",
         "requirements":[]
+    },
+    {
+        "name": "Vaden Security",
+        "description": "Vaden Security is a package that provides a security layer for Vaden.",
+        "key": "vaden_security",
+        "tag": "SECURITY",
+        "requirements":[]
     }
 ]
 

--- a/vaden_generator/backend/assets/metadata.json
+++ b/vaden_generator/backend/assets/metadata.json
@@ -48,6 +48,13 @@
           "key": "cron",
           "tag": "SYSTEM",
           "requirements":[]
+        },
+        {
+          "name": "Vaden Security",
+          "description": "Vaden Security is a package that provides a security layer for Vaden.",
+          "key": "vaden_security",
+          "tag": "SECURITY",
+          "requirements":[]
         }
       ],
     "defaultDartVersion": {

--- a/vaden_generator/backend/lib/config/app_controller_advice.dart
+++ b/vaden_generator/backend/lib/config/app_controller_advice.dart
@@ -12,9 +12,11 @@ class AppControllerAdvice {
   Future<Response> handleDioException(DioException e) async {
     return Response(
       e.response?.statusCode ?? 500,
-      body: jsonEncode({
-        'message': e.response?.data['message'] ?? 'Internal server error',
-      }),
+      body: jsonEncode(
+        {
+          'message': e.response?.data['message'] ?? 'Internal server error',
+        },
+      ),
     );
   }
 
@@ -26,9 +28,11 @@ class AppControllerAdvice {
   @ExceptionHandler(Exception)
   Response handleException(Exception e) {
     return Response.internalServerError(
-      body: jsonEncode({
-        'message': 'Internal server error',
-      }),
+      body: jsonEncode(
+        {
+          'message': 'Internal server error',
+        },
+      ),
     );
   }
 }

--- a/vaden_generator/backend/lib/config/openapi/openapi_controller.dart
+++ b/vaden_generator/backend/lib/config/openapi/openapi_controller.dart
@@ -21,8 +21,11 @@ class OpenAPIController {
 
   @Get('/openapi.json')
   FutureOr<Response> getOpenApiJSON(Request request) {
-    return Response.ok(swaggerUI.schemaText, headers: {
-      'Content-Type': 'application/json',
-    });
+    return Response.ok(
+      swaggerUI.schemaText,
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    );
   }
 }

--- a/vaden_generator/backend/lib/src/controllers/generate_controller.dart
+++ b/vaden_generator/backend/lib/src/controllers/generate_controller.dart
@@ -23,7 +23,9 @@ class GenerateController {
   );
 
   @ApiOperation(
-      summary: 'Get dependencies', description: 'Get all dependencies')
+    summary: 'Get dependencies',
+    description: 'Get all dependencies',
+  )
   @ApiResponse(
     200,
     description: 'Dependencies returned',
@@ -64,13 +66,13 @@ class GenerateController {
     content: ApiContent(type: 'application/json', schema: ProjectLinkDTO),
   )
   @Post('/create')
-  Future<ProjectLinkDTO> createDeprecated(
-      @Body() ProjectDepreciated dto) async {
+  Future<ProjectLinkDTO> createDeprecated(@Body() ProjectDepreciated dto) async {
     final newDto = Project(
-        dependenciesKeys: dto.dependencies.map((d) => d.key).toList(),
-        projectName: dto.projectName,
-        projectDescription: dto.projectDescription,
-        dartVersion: dto.dartVersion);
+      dependenciesKeys: dto.dependencies.map((d) => d.key).toList(),
+      projectName: dto.projectName,
+      projectDescription: dto.projectDescription,
+      dartVersion: dto.dartVersion,
+    );
 
     return await _createProject.call(newDto).getOrThrow();
   }

--- a/vaden_generator/backend/lib/src/core/files/file_manager.dart
+++ b/vaden_generator/backend/lib/src/core/files/file_manager.dart
@@ -32,12 +32,12 @@ class FileManager {
     final tempDirName = Uuid().v4();
 
     return Directory(
-            '${dir.path}${Platform.pathSeparator}$tempDirName${Platform.pathSeparator}$name') //
-        .create(recursive: true);
+      '${dir.path}${Platform.pathSeparator}$tempDirName${Platform.pathSeparator}$name',
+    ).create(recursive: true);
   }
 
-  FileGenerator getGenerator(String key) {
-    return _generators[key]!;
+  FileGenerator? getGenerator(String key) {
+    return _generators[key];
   }
 
   Future<void> insertLineInFile(
@@ -73,10 +73,10 @@ class FileManager {
   Future<List<int>> createZip(String folderPath, String projectName) async {
     final archive = Archive();
 
-    final files = Directory(folderPath)
-        .listSync(recursive: true)
-        .whereType<File>()
-        .toList();
+    final files = Directory(folderPath) //
+    .listSync(recursive: true) //
+    .whereType<File>() //
+    .toList();
 
     for (var file in files) {
       final fileBytes = await file.readAsBytes();

--- a/vaden_generator/backend/lib/src/core/files/generators/initial_project.dart
+++ b/vaden_generator/backend/lib/src/core/files/generators/initial_project.dart
@@ -42,32 +42,56 @@ class InitialProjectGenerator extends FileGenerator {
     await dockerIgnore.create(recursive: true);
     await dockerIgnore.writeAsString(_dockerIgnoreContent);
 
-    final publicIndex = File('${directory.path}${Platform.pathSeparator}public${Platform.pathSeparator}index.html');
+    final publicIndex = File(
+      '${directory.path}${Platform.pathSeparator}public${Platform.pathSeparator}index.html',
+    );
     await publicIndex.create(recursive: true);
     await publicIndex.writeAsString(parseVariables(_publicIndexContent, variables));
 
-    final binServer = File('${directory.path}${Platform.pathSeparator}bin${Platform.pathSeparator}server.dart');
+    final binServer = File(
+      '${directory.path}${Platform.pathSeparator}bin${Platform.pathSeparator}server.dart',
+    );
     await binServer.create(recursive: true);
     await binServer.writeAsString(parseVariables(_binServerContent, variables));
 
-    final libConfigAppConfiguration = File('${directory.path}${Platform.pathSeparator}lib${Platform.pathSeparator}config${Platform.pathSeparator}app_configuration.dart');
+    final libConfigAppConfiguration = File(
+      '${directory.path}${Platform.pathSeparator}lib${Platform.pathSeparator}config${Platform.pathSeparator}app_configuration.dart',
+    );
     await libConfigAppConfiguration.create(recursive: true);
     await libConfigAppConfiguration.writeAsString(_libConfigAppConfigurationContent);
 
-    final libConfigAppModule = File('${directory.path}${Platform.pathSeparator}lib${Platform.pathSeparator}config${Platform.pathSeparator}app_module.dart');
-    await libConfigAppModule.create(recursive: true);
-    await libConfigAppModule.writeAsString(_libConfigAppModuleContent);
+    final List<String> dependenciesKeys = variables['dependenciesKeys'] as List<String>? ?? [];
+    final bool hasVadenSecurity = dependenciesKeys.contains('vaden_security');
 
-    final libConfigResourcesResourceConfiguration =
-        File('${directory.path}${Platform.pathSeparator}lib${Platform.pathSeparator}config${Platform.pathSeparator}resources${Platform.pathSeparator}resource_configuration.dart');
+    if (hasVadenSecurity) {
+      final vadenSecurityVersion = variables['vaden_security'] ?? '^0.0.3';
+      await fileManager.insertLineInFile(
+        pubspec,
+        RegExp(r'dependencies:'),
+        '  vaden_security: $vadenSecurityVersion',
+        position: InsertLinePosition.after,
+      );
+
+      final appModulePath =
+          '${directory.path}${Platform.pathSeparator}lib${Platform.pathSeparator}config${Platform.pathSeparator}app_module.dart';
+      final libConfigAppModule = File(appModulePath);
+      await libConfigAppModule.create(recursive: true);
+      await libConfigAppModule.writeAsString(_libConfigAppModuleContent);
+    }
+
+    final libConfigResourcesResourceConfiguration = File(
+        '${directory.path}${Platform.pathSeparator}lib${Platform.pathSeparator}config${Platform.pathSeparator}resources${Platform.pathSeparator}resource_configuration.dart',);
     await libConfigResourcesResourceConfiguration.create(recursive: true);
-    await libConfigResourcesResourceConfiguration.writeAsString(_libConfigResourcesResourceConfigurationContent);
+    await libConfigResourcesResourceConfiguration
+        .writeAsString(_libConfigResourcesResourceConfigurationContent);
 
-    final srcHelloController = File('${directory.path}${Platform.pathSeparator}lib${Platform.pathSeparator}src${Platform.pathSeparator}hello_controller.dart');
+    final srcHelloController = File(
+        '${directory.path}${Platform.pathSeparator}lib${Platform.pathSeparator}src${Platform.pathSeparator}hello_controller.dart',);
     await srcHelloController.create(recursive: true);
     await srcHelloController.writeAsString(_srcHelloControllerContent);
 
-    final libConfigAppControllerAdvice = File('${directory.path}${Platform.pathSeparator}lib${Platform.pathSeparator}config${Platform.pathSeparator}app_controller_advice.dart');
+    final libConfigAppControllerAdvice = File(
+        '${directory.path}${Platform.pathSeparator}lib${Platform.pathSeparator}config${Platform.pathSeparator}app_controller_advice.dart',);
     await libConfigAppControllerAdvice.create(recursive: true);
     await libConfigAppControllerAdvice.writeAsString(_libConfigAppControllerAdviceContent);
   }
@@ -235,6 +259,7 @@ class AppConfiguration {
 ''';
 
 const _libConfigAppModuleContent = '''import 'package:vaden/vaden.dart';
+import 'package:vaden_security/vaden_security.dart';
 
 @VadenModule([VadenSecurity])
 class AppModule {}

--- a/vaden_generator/backend/lib/src/data/repositories/dependency_repository_impl.dart
+++ b/vaden_generator/backend/lib/src/data/repositories/dependency_repository_impl.dart
@@ -23,10 +23,12 @@ class DependencyRepositoryImpl implements DependencyRepository {
     final file = File('assets${Platform.pathSeparator}dependencies.json');
 
     if (!file.existsSync()) {
-      return Failure(ResponseException(
-        404,
-        {'message': 'Dependencies file not found'},
-      ));
+      return Failure(
+        ResponseException(
+          404,
+          {'message': 'Dependencies file not found'},
+        ),
+      );
     }
 
     final content = await file.readAsString();

--- a/vaden_generator/backend/lib/src/data/repositories/matadate_repository_impl.dart
+++ b/vaden_generator/backend/lib/src/data/repositories/matadate_repository_impl.dart
@@ -23,10 +23,12 @@ class MatadateRepositoryImpl implements MatadateRepository {
     final file = File('assets${Platform.pathSeparator}metadata.json');
 
     if (!file.existsSync()) {
-      return Failure(ResponseException(
-        404,
-        {'message': 'Metadata file not found'},
-      ));
+      return Failure(
+        ResponseException(
+          404,
+          {'message': 'Metadata file not found'},
+        ),
+      );
     }
 
     final content = await file.readAsString();

--- a/vaden_generator/backend/lib/src/domain/entities/dart_version.dart
+++ b/vaden_generator/backend/lib/src/domain/entities/dart_version.dart
@@ -15,7 +15,10 @@ class DartVersion with Validator<DartVersion> {
     builder //
         .ruleFor((p) => p.id, key: 'dartVersion')
         .notEmpty()
-        .matchesPattern(r"^\d+\.\d+\.\d+$", message: "Invalid dart version");
+        .matchesPattern(
+          r"^\d+\.\d+\.\d+$",
+          message: "Invalid dart version",
+        );
 
     return builder;
   }

--- a/vaden_generator/backend/lib/src/domain/services/generate_service.dart
+++ b/vaden_generator/backend/lib/src/domain/services/generate_service.dart
@@ -6,7 +6,9 @@ import 'package:result_dart/result_dart.dart';
 
 abstract interface class GenerateService {
   AsyncResult<ProjectWithTempPath> createTempProject(
-      Project project, Directory tempFolder);
+    Project project,
+    Directory tempFolder,
+  );
   AsyncResult<ProjectWithTempPath> addDependencies(ProjectWithTempPath project);
   AsyncResult<ProjectLinkDTO> createZipLink(ProjectWithTempPath project);
 }


### PR DESCRIPTION
### 📄 Descrição
Ajusta a geração do app_module.dart para que seja criado somente quando a dependência vaden_security for selecionada, evitando erros no projeto quando esta não for incluída.

### 🔄 Mudanças Realizadas
- [x] Condição para gerar app_module.dart apenas com vaden_security selecionado
- [x] Adição da dependência no pubspec.yaml somente quando necessária

### ✅ Checklist

- [x] Testes foram adicionados ou atualizados.
- [x] Documentação foi atualizada (se necessário).
- [x] Revisão de código completa.

### 🔗 Issue Relacionada

Resolves #86 