### PR TITLE
New @Parse Annotation

### DIFF
--- a/doc/docs/basic-usage/dto.mdx
+++ b/doc/docs/basic-usage/dto.mdx
@@ -138,6 +138,31 @@ class DebugService {
 }
 ```
 
+## `@Parse` Annotation
+
+The `@Parse` annotation allows `ParamParse` classes (such as `DateTimeParse`) to be defined in separate files and reused across multiple DTOs.
+
+When a `ParamParse` class is annotated with `@Parse`, it becomes globally discoverable, enabling it to be imported and used across different DTOs without needing to duplicate parsing logic.
+
+### Example
+
+**Parse Class (in its own file):**
+```dart
+@Parse()
+class DateTimeParse extends ParamParse<DateTime?, String> {
+  const DateTimeParse();
+
+  @override
+  String toJson(DateTime? param) {
+    return param?.toIso8601String() ?? '';
+  }
+
+  @override
+  DateTime? fromJson(String? json) {
+    return DateTime.tryParse(json ?? '');
+  }
+}
+
 ## Benefits
 
 - No need to write boilerplate serializers.

--- a/doc/docs/basic-usage/warm_up.md
+++ b/doc/docs/basic-usage/warm_up.md
@@ -1,0 +1,80 @@
+---
+sidebar_position: 5
+---
+
+# Initialization Warm Up
+
+Vaden includes a built-in initialization warm-up process to ensure critical startup tasks are completed **before** the server begins handling requests.  
+
+## AppWarmup
+
+To configure initialization tasks, you should now create a class like `app_warmup.dart` and define components that implement either:
+
+- `ApplicationRunner` – runs when the application starts, regardless of arguments.
+- `CommandLineRunner` – runs based on specific command-line arguments passed at startup.
+
+Example:
+
+```dart
+import 'package:vaden/vaden.dart';
+
+@Component()
+class AppWarmup implements ApplicationRunner {
+  @override
+  Future<void> run(VadenApplication app) async {
+    print('ApplicationRunner');
+  }
+}
+
+@Component()
+class AppRunner implements CommandLineRunner {
+  @override
+  Future<void> run(List<String> args) async {
+    print('My args: $args');
+  }
+}
+```
+
+### ApplicationRunner
+
+- Runs automatically at application startup.
+- Suitable for general initialization tasks like setting up services, running migrations, preparing caches, etc.
+
+Example:
+
+```dart
+@Component()
+class AppWarmup implements ApplicationRunner {
+  @override
+  Future<void> run(VadenApplication app) async {
+    await prepareDatabase();
+    initializeLogger();
+  }
+}
+```
+
+### CommandLineRunner
+
+- Runs based on the command-line arguments passed to the app.
+- Allows conditional startup behavior based on the arguments.
+
+Example:
+
+```dart
+@Component()
+class AppRunner implements CommandLineRunner {
+  @override
+  Future<void> run(List<String> args) async {
+    if (args.contains('migrate')) {
+      await runMigrations();
+    } else if (args.contains('seed')) {
+      await seedDatabase();
+    }
+  }
+}
+```
+
+### Error Handling
+
+- If any `run` method throws an exception, the error is printed and the server will **not start**.
+- This ensures the application never runs in a partially initialized state.

--- a/vaden/example/lib/src/dtos/date_time_parse.dart
+++ b/vaden/example/lib/src/dtos/date_time_parse.dart
@@ -1,0 +1,16 @@
+import 'package:vaden/vaden.dart';
+
+@Parse()
+class DateTimeParse extends ParamParse<DateTime?, String> {
+  const DateTimeParse();
+
+  @override
+  String toJson(DateTime? param) {
+    return param?.toIso8601String() ?? '';
+  }
+
+  @override
+  DateTime? fromJson(String? json) {
+    return DateTime.tryParse(json ?? '');
+  }
+}

--- a/vaden/example/lib/src/dtos/parse_dto.dart
+++ b/vaden/example/lib/src/dtos/parse_dto.dart
@@ -1,3 +1,4 @@
+import 'package:example/src/dtos/date_time_parse.dart';
 import 'package:vaden/vaden.dart';
 
 @DTO()
@@ -15,18 +16,4 @@ class ParseDto {
     required this.createdAt,
     required this.updatedAt,
   });
-}
-
-class DateTimeParse extends ParamParse<DateTime?, String> {
-  const DateTimeParse();
-
-  @override
-  String toJson(DateTime? param) {
-    return param?.toIso8601String() ?? '';
-  }
-
-  @override
-  DateTime? fromJson(String? json) {
-    return DateTime.tryParse(json ?? '');
-  }
 }

--- a/vaden/lib/src/annotations/annotation.dart
+++ b/vaden/lib/src/annotations/annotation.dart
@@ -587,6 +587,13 @@ class Context {
   const Context(this.name);
 }
 
+class Parse implements BaseComponent {
+  const Parse();
+
+  @override
+  final bool registerWithInterfaceOrSuperType = false;
+}
+
 class UseParse {
   final Type parser;
 

--- a/vaden/lib/src/annotations/annotation.dart
+++ b/vaden/lib/src/annotations/annotation.dart
@@ -587,20 +587,70 @@ class Context {
   const Context(this.name);
 }
 
+/// Marks a class as a reusable ParamParse definition.
+///
+/// Classes annotated with [Parse] become globally discoverable,
+/// allowing them to be reused across multiple DTOs for serialization
+/// and deserialization logic.
+///
+/// Example:
+/// ```dart
+/// @Parse()
+/// class DateTimeParse extends ParamParse<DateTime?, String> {
+///   const DateTimeParse();
+///
+///   @override
+///   String toJson(DateTime? param) => param?.toIso8601String() ?? '';
+///
+///   @override
+///   DateTime? fromJson(String? json) => DateTime.tryParse(json ?? '');
+/// }
+/// ```
 class Parse implements BaseComponent {
+  /// Creates a Parse annotation.
   const Parse();
 
   @override
   final bool registerWithInterfaceOrSuperType = false;
 }
 
+/// Specifies a parser to use for a field in a DTO.
+///
+/// [UseParse] allows you to associate a specific [ParamParse] class
+/// with a field, enabling custom serialization and deserialization logic.
+///
+/// Example:
+/// ```dart
+/// @DTO()
+/// class ExampleDTO {
+///   @UseParse(DateTimeParse)
+///   final DateTime timestamp;
+///
+///   ExampleDTO({required this.timestamp});
+/// }
+/// ```
 class UseParse {
+  /// The parser class to use for this field.
   final Type parser;
 
+  /// Creates a UseParse annotation specifying the parser class.
   const UseParse(this.parser);
 }
 
+/// Defines a Vaden module that can import multiple components.
+///
+/// [VadenModule] allows grouping and importing components, configurations,
+/// services, and other modules into a single module for better project organization.
+///
+/// Example:
+/// ```dart
+/// @VadenModule([UserService, AuthService, DatabaseConfig])
+/// class AppModule {}
+/// ```
 class VadenModule {
+  /// The list of types to import into the module.
   final List<Type> imports;
+
+  /// Creates a VadenModule annotation with the specified imports.
   const VadenModule(this.imports);
 }

--- a/vaden/lib/src/types/application_runner.dart
+++ b/vaden/lib/src/types/application_runner.dart
@@ -1,5 +1,29 @@
 import 'package:vaden/src/types/vaden_application.dart';
 
+/// Defines a contract for components that should execute
+/// automatically during application startup.
+///
+/// Classes that implement [ApplicationRunner] are discovered and
+/// executed before the server begins handling any requests.
+///
+/// Typical use cases include:
+/// - Initializing resources
+/// - Running database migrations
+/// - Preloading caches
+/// - Setting up external service connections
+///
+/// The [run] method receives the [VadenApplication] instance,
+/// allowing access to configuration, context, and registered beans.
+///
+/// If an exception is thrown during execution, the application
+/// startup process will fail, preventing the server from starting.
 abstract class ApplicationRunner {
+  /// Executes startup logic before the server becomes ready.
+  ///
+  /// The [app] parameter provides access to the running
+  /// [VadenApplication] instance.
+  ///
+  /// Throws an exception to prevent the server from starting
+  /// if initialization fails.
   Future<void> run(VadenApplication app);
 }

--- a/vaden/lib/src/types/commandline_runner.dart
+++ b/vaden/lib/src/types/commandline_runner.dart
@@ -1,3 +1,25 @@
+/// Defines a contract for components that should execute
+/// based on command-line arguments during application startup.
+///
+/// Classes that implement [CommandLineRunner] are discovered and
+/// executed with the arguments passed when starting the application.
+///
+/// Typical use cases include:
+/// - Running database migrations manually
+/// - Seeding test data
+/// - Starting background jobs
+///
+/// The [run] method receives the list of [args] provided at startup.
+///
+/// If an exception is thrown during execution, the application
+/// startup process will fail, preventing the server from starting.
 abstract class CommandLineRunner {
+  /// Executes logic based on the provided command-line arguments.
+  ///
+  /// The [args] parameter contains the list of arguments passed
+  /// when the application was started.
+  ///
+  /// Throws an exception to prevent the server from starting
+  /// if initialization fails.
   Future<void> run(List<String> args);
 }

--- a/vaden/lib/src/types/vaden_application.dart
+++ b/vaden/lib/src/types/vaden_application.dart
@@ -2,16 +2,47 @@ import 'dart:io';
 
 import 'package:vaden/vaden.dart';
 
+/// Represents the core application structure in Vaden,
+/// managing server startup, dependency injection, and routing.
+///
+/// [VadenApplication] defines the main lifecycle methods and
+/// infrastructure components required to run a Vaden server.
+///
+/// It provides access to:
+/// - The [Injector] for dependency management
+/// - The [Router] for HTTP route handling
+///
+/// Applications must extend this class to configure and launch
+/// their services.
+///
+/// The [instance] field holds a static reference to the running
+/// application and must be initialized using [registerInstance].
 abstract class VadenApplication {
+  /// Starts the HTTP server and runs the application with the
+  /// provided command-line [args].
+  ///
+  /// Returns the [HttpServer] instance once started.
   Future<HttpServer> run(List<String> args);
+
+  /// Sets up internal application components, dependency injection,
+  /// and middleware before the server starts.
   Future<void> setup();
 
+  /// Provides access to the dependency [Injector] containing
+  /// all registered beans and services.
   Injector get injector;
 
+  /// Provides access to the [Router] instance used for
+  /// defining HTTP routes.
   Router get router;
 
+  /// Holds the global static instance of the running application.
   static late final VadenApplication instance;
 
+  /// Registers the global application [instance].
+  ///
+  /// This must be called during the application initialization
+  /// to allow access to the application context.
   static void registerInstance(VadenApplication app) {
     instance = app;
   }

--- a/vaden_class_scanner/lib/src/aggregating_vaden_builder.dart
+++ b/vaden_class_scanner/lib/src/aggregating_vaden_builder.dart
@@ -31,6 +31,7 @@ class AggregatingVadenBuilder implements Builder {
   final componentChecker = TypeChecker.fromRuntime(BaseComponent);
   final dtoChecker = TypeChecker.fromRuntime(DTO);
   final moduleChecker = TypeChecker.fromRuntime(VadenModule);
+  final parseChecker = TypeChecker.fromRuntime(Parse);
 
   @override
   Future<void> build(BuildStep buildStep) async {
@@ -211,6 +212,8 @@ class _DSON extends DSON {
     if (dtoChecker.hasAnnotationOf(classElement) || configurationChecker.hasAnnotationOf(classElement)) {
       return '';
     } else if (moduleChecker.hasAnnotationOf(classElement)) {
+      return '';
+    } else if (parseChecker.hasAnnotationOf(classElement)) {
       return '';
     }
 


### PR DESCRIPTION
This PR introduces a new annotation called `@Parse`.  

The goal of `@Parse` is to allow `ParamParse` classes (such as `DateTimeParse`) to be defined in separate files and reused across multiple DTOs.

Previously, for a `ParamParse` class to be used by a DTO, it had to be declared in the same file as the DTO itself.  
This limitation made code less modular and harder to maintain.

Now, by annotating a `ParamParse` class with `@Parse`, it becomes globally discoverable, enabling it to be imported and reused across different DTOs without needing to duplicate the parse logic.

### Example

**Parse Class (separated into its own file):**

```dart
@Parse()
class DateTimeParse extends ParamParse<DateTime?, String> {
  const DateTimeParse();

  @override
  String toJson(DateTime? param) {
    return param?.toIso8601String() ?? '';
  }

  @override
  DateTime? fromJson(String? json) {
    return DateTime.tryParse(json ?? '');
  }
}
```

**DTO Using the Parse Class:**

```dart
@DTO()
class BaseDto {
  final String id;

  @UseParse(DateTimeParse)
  final DateTime createdAt;

  @UseParse(DateTimeParse)
  final DateTime? updatedAt;

  BaseDto({
    required this.id,
    required this.createdAt,
    required this.updatedAt,
  });
}
```

With this new system, `DateTimeParse` can now live in its own dedicated file and be easily reused across multiple DTOs.