### PR TITLE
Feat: Initialization Warm Up

### DIFF
--- a/doc/docs/basic-usage/dto.mdx
+++ b/doc/docs/basic-usage/dto.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 6
+sidebar_position: 7
 ---
 
 # Data Transfer Object (DTO)

--- a/doc/docs/basic-usage/exception-handling.md
+++ b/doc/docs/basic-usage/exception-handling.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 7
+sidebar_position: 8
 ---
 
 # Exception Handling

--- a/doc/docs/basic-usage/initialization_warm_up.md
+++ b/doc/docs/basic-usage/initialization_warm_up.md
@@ -1,0 +1,98 @@
+---
+sidebar_position: 5
+---
+
+# Initialization Warm Up
+
+Vaden includes a built-in initialization warm-up process to ensure critical startup tasks are completed **before** the server begins handling requests.  
+This system allows for operations such as database migrations, cache preloading, or external service connections to be executed during application boot.
+
+By default, the initialization system runs no tasks unless you explicitly provide them.
+
+## Boot Method
+
+Inside your `@Configuration()` class, you can define the `boot` method, which returns an `InitializationSettings`.  
+This method executes a list of startup functions before the server starts:
+
+```dart
+@Configuration()
+class AppConfiguration {
+  @Bean()
+  ApplicationSettings settings() {
+    return ApplicationSettings.load('application.yaml');
+  }
+
+  @Bean()
+  Future<InitializationSettings> boot() async {
+    return InitializationSettings.load([]);
+  }
+
+  @Bean()
+  Pipeline globalMiddleware(ApplicationSettings settings) {
+    return Pipeline()
+        .addMiddleware(cors(allowedOrigins: ['*']))
+        .addVadenMiddleware(EnforceJsonContentType())
+        .addMiddleware(logRequests());
+  }
+}
+```
+
+At startup, the server will wait for all functions in the list to complete successfully.  
+If any function fails (throws an error), the server **will not start**.
+
+## Adding Initialization Functions
+
+You can specify which tasks should run by adding them to the list passed to `InitializationSettings.load()`:
+
+```dart
+@Bean()
+Future<InitializationSettings> boot(Initialization init) async {
+  return InitializationSettings.load([
+    init.start,
+  ]);
+}
+```
+
+Each function in the list can be either synchronous or asynchronous (`Future`).  
+They are all awaited before the server becomes ready.
+
+## Example Usage
+
+Suppose you have some initialization tasks like preparing a database or initializing a logger:
+
+```dart
+Future<void> prepareDatabase() async {
+  // Run database migrations here
+}
+
+void initializeLogger() {
+  // Set up your logging system
+}
+
+@Bean()
+Future<InitializationSettings> boot() async {
+  return InitializationSettings.load([
+    prepareDatabase,
+    initializeLogger,
+  ]);
+}
+```
+
+In this case:
+- `prepareDatabase` runs and waits for completion.
+- `initializeLogger` runs immediately since it is synchronous.
+- Only if all tasks succeed will the server start.
+
+## Error Handling
+
+- If any function throws an exception, the error and stack trace are **printed to the console**.
+- The server **will not start** if initialization fails.
+
+Example log output on failure:
+
+```
+Error starting functions: DatabaseException: Migration failed
+StackTrace: ...
+```
+
+This ensures your application never runs in a partially initialized or unstable state.

--- a/vaden/example/lib/config/app_configuration.dart
+++ b/vaden/example/lib/config/app_configuration.dart
@@ -1,3 +1,4 @@
+import 'package:example/config/initialization/initialization_configuration.dart';
 import 'package:vaden/vaden.dart';
 
 @Configuration()
@@ -5,6 +6,11 @@ class AppConfiguration {
   @Bean()
   ApplicationSettings settings() {
     return ApplicationSettings.load('application.yaml');
+  }
+
+  @Bean()
+  Future<InitializationSettings> boot(Initialization init) async {
+    return InitializationSettings.load([]);
   }
 
   @Bean()

--- a/vaden/example/lib/config/initialization/initialization_configuration.dart
+++ b/vaden/example/lib/config/initialization/initialization_configuration.dart
@@ -1,0 +1,26 @@
+import 'package:vaden/vaden.dart';
+
+@Configuration()
+class InitializationConfiguration {
+  @Bean()
+  Future<Initialization> init(ApplicationSettings settings) async {
+    return Initialization(text: settings['openapi']['title']);
+  }
+}
+
+class Initialization {
+  final String text;
+
+  Initialization({required this.text});
+
+  Future<void> start() async {
+    await Future.delayed(Duration(seconds: 3));
+    print(text);
+    print('Start boot');
+  }
+
+  Future<void> error() async {
+    await Future.delayed(Duration(seconds: 3));
+    throw Exception('error');
+  }
+}

--- a/vaden/lib/src/utils/app_initialization.dart
+++ b/vaden/lib/src/utils/app_initialization.dart
@@ -1,0 +1,90 @@
+/// A class for managing and tracking the application's initialization process.
+///
+/// The InitializationSettings class provides a mechanism to execute a list of asynchronous
+/// or synchronous initialization functions during the startup of the application. It waits
+/// for all provided functions to complete before proceeding and tracks whether the initialization
+/// was successful.
+///
+/// This is useful for setting up services, loading essential resources, or performing
+/// any startup tasks that must be completed before the application becomes fully operational.
+///
+/// Example usage:
+/// ```dart
+/// Future<void> initializeDatabase() async {
+///   // Database initialization logic
+/// }
+///
+/// void initializeLogger() {
+///   // Logger setup logic
+/// }
+///
+/// void main() async {
+///   final initialization = await InitializationSettings.load([
+///     initializeDatabase,
+///     initializeLogger,
+///   ]);
+///
+///   if (initialization()) {
+///     print('Application initialized successfully.');
+///   } else {
+///     print('Application failed to initialize.');
+///   }
+/// }
+/// ```
+///
+/// This approach ensures that all necessary startup tasks are completed in a
+/// safe and consistent manner, improving application stability.
+class InitializationSettings {
+  /// Internal flag indicating whether all initialization functions completed successfully.
+  final bool _completed;
+
+  /// Private constructor that initializes the [_completed] status.
+  ///
+  /// This constructor is private to enforce the use of the [load] factory method
+  /// for creating instances of InitializationSettings.
+  InitializationSettings._(this._completed);
+
+  /// Executes a list of initialization functions and waits for their completion.
+  ///
+  /// This factory method runs each function provided in the [functions] list. It automatically
+  /// handles both synchronous and asynchronous functions, ensuring that all functions are completed.
+  /// If any function throws an exception, the initialization is considered failed.
+  ///
+  /// Parameters:
+  /// - [functions]: A list of functions to execute. Each function can return either
+  ///   a Future or void.
+  ///
+  /// Returns:
+  /// - An InitializationSettings instance indicating whether initialization was successful.
+  ///
+  /// Example:
+  /// ```dart
+  /// final settings = await InitializationSettings.load([setupCache, initializeServices]);
+  /// if (settings()) { ... }
+  /// ```
+  static Future<InitializationSettings> load(List<Function> functions) async {
+    try {
+      await Future.wait(functions.map((function) {
+        var result = function();
+        if (result is Future) {
+          return result;
+        } else {
+          return Future.value();
+        }
+      }));
+      return InitializationSettings._(true);
+    } catch (e, stackTrace) {
+      print('Error starting functions: $e');
+      print('StackTrace: $stackTrace');
+      return InitializationSettings._(false);
+    }
+  }
+
+  /// Returns the completion status of the initialization process.
+  ///
+  /// This operator allows checking whether all initialization functions completed successfully.
+  ///
+  /// Returns:
+  /// - `true` if initialization was successful, `false` otherwise.
+  bool operator() => _completed;
+}

--- a/vaden/lib/vaden.dart
+++ b/vaden/lib/vaden.dart
@@ -62,6 +62,7 @@ export 'src/types/types.dart';
 
 // Utility classes and services
 export 'src/utils/app_configuration.dart';
+export 'src/utils/app_initialization.dart';
 export 'src/utils/openapi_config.dart';
 export 'src/utils/resource_service.dart';
 export 'src/utils/storage/storage.dart';

--- a/vaden_class_scanner/lib/src/aggregating_vaden_builder.dart
+++ b/vaden_class_scanner/lib/src/aggregating_vaden_builder.dart
@@ -61,25 +61,29 @@ class AggregatingVadenBuilder implements Builder {
     aggregatedBuffer.writeln();
     aggregatedBuffer.writeln('''
   Future<HttpServer> run() async {
-    final pipeline = _injector.get<Pipeline>();
-    final handler = pipeline.addHandler((request) async {
-      try {
-        final response = await _router(request);
-        return response;
-      } catch (e, stack) {
-        print(e);
-        print(stack);
-        return _handleException(e);
-      }
-    });
+    final initialization = _injector.get<InitializationSettings>();
+    if (initialization.operator()) {
+      final pipeline = _injector.get<Pipeline>();
+      final handler = pipeline.addHandler((request) async {
+        try {
+          final response = await _router(request);
+          return response;
+        } catch (e, stack) {
+          print(e);
+          print(stack);
+          return _handleException(e);
+        }
+      });
 
-    final settings = _injector.get<ApplicationSettings>();
-    final port = settings['server']['port'] ?? 8080;
-    final host = settings['server']['host'] ?? '0.0.0.0';
+      final settings = _injector.get<ApplicationSettings>();
+      final port = settings['server']['port'] ?? 8080;
+      final host = settings['server']['host'] ?? '0.0.0.0';
 
-    final server = await serve(handler, host, port);
+      final server = await serve(handler, host, port);
 
-    return server;
+      return server;
+    }
+    throw Exception('Initialization failed');
   }
 ''');
     aggregatedBuffer.writeln();

--- a/vaden_generator/backend/lib/src/core/files/generators/initial_project.dart
+++ b/vaden_generator/backend/lib/src/core/files/generators/initial_project.dart
@@ -247,6 +247,11 @@ class AppConfiguration {
   ApplicationSettings settings() {
     return ApplicationSettings.load('application.yaml');
   }
+  
+  @Bean()
+  Future<InitializationSettings> boot(Initialization init) async {
+    return InitializationSettings.load([]);
+  }
 
   @Bean()
   Pipeline globalMiddleware(ApplicationSettings settings) {

--- a/vaden_generator/backend/lib/src/core/files/generators/initial_project.dart
+++ b/vaden_generator/backend/lib/src/core/files/generators/initial_project.dart
@@ -250,6 +250,7 @@ class AppConfiguration {
   
   @Bean()
   Future<InitializationSettings> boot(Initialization init) async {
+  Future<InitializationSettings> boot() async {
     return InitializationSettings.load([]);
   }
 


### PR DESCRIPTION
This PR introduces a **warm-up initialization system** for the application startup phase.  
It ensures that critical tasks such as database migrations, cache preloading, or external service connections are fully executed **before** the server starts accepting requests.

A new `boot` method has been added to the `AppConfiguration` class, allowing developers to define a list of initialization functions to be executed at startup.  
The server will only start if all these functions complete successfully; otherwise, startup will fail safely, preventing unstable states.

### Changes Introduced
- Added `boot` method returning `InitializationSettings` in `AppConfiguration`.
- Functions can be manually added to the initialization list.
- If any initialization function fails, the server startup is aborted.
- Initialization is always present but defaults to an empty list (no functions).
- Updated documentation: created `initialization_warm_up.md` to explain the feature.

### Example

```dart
@Bean()
Future<InitializationSettings> boot(Initialization init) async {
  return InitializationSettings.load([
    init.start,
  ]);
}
```

### Motivation

- Guarantee that important setup tasks are not skipped.
- Prevent the server from starting in a broken or partially ready state.
- Provide a clean and scalable way to manage startup tasks.