### PR TITLE
feat: Added enhance dependency dialog with multi-selection and confirmation…

### DIFF
--- a/vaden_generator/frontend/lib/i18n/en_US.json
+++ b/vaden_generator/frontend/lib/i18n/en_US.json
@@ -28,5 +28,7 @@
   "notEmpty": "Cannot be empty",
   "addDependencies": "Add dependencies",
   "reservedKeyword": "The name cannot be a Dart reserved keyword or the framework name (Vaden)",
-  "search_dependencies": "Search dependency"
+  "search_dependencies": "Search dependency",
+  "cancel": "Cancel",
+  "confirm": "Confirm"
 }

--- a/vaden_generator/frontend/lib/i18n/es_ES.json
+++ b/vaden_generator/frontend/lib/i18n/es_ES.json
@@ -28,5 +28,7 @@
   "notEmpty": "No puede estar vacío",
   "addDependencies": "Añadir dependencias",
   "reservedKeyword": "El nombre no puede ser una palabra reservada de Dart o el nombre del framework (Vaden)",
-  "search_dependencies": "Buscar dependencia"
+  "search_dependencies": "Buscar dependencia",
+  "cancel": "Cancelar",
+  "confirm": "Confirmar"
 }

--- a/vaden_generator/frontend/lib/i18n/pt_BR.json
+++ b/vaden_generator/frontend/lib/i18n/pt_BR.json
@@ -28,5 +28,7 @@
   "notEmpty": "Não pode estar vazio",
   "addDependencies": "Adicionar dependencias",
   "reservedKeyword": "O nome não pode ser uma palavra reservada do Dart ou o nome do framework (Vaden)",
-  "search_dependencies": "Buscar dependência"
+  "search_dependencies": "Buscar dependência",
+  "cancel": "Cancelar",
+  "confirm": "Confirmar"
 }

--- a/vaden_generator/frontend/lib/ui/generate/generate_page.dart
+++ b/vaden_generator/frontend/lib/ui/generate/generate_page.dart
@@ -55,7 +55,11 @@ class _GeneratePageState extends State<GeneratePage> {
 
     if (result != null) {
       setState(() {
-        project.dependenciesKeys.add(result.key);
+        for (final dep in result) {
+          if (!project.dependenciesKeys.contains(dep.key)) {
+            project.dependenciesKeys.add(dep.key);
+          }
+        }
       });
     }
   }

--- a/vaden_generator/frontend/lib/ui/generate/widgets/vaden_dependencies_dialog.dart
+++ b/vaden_generator/frontend/lib/ui/generate/widgets/vaden_dependencies_dialog.dart
@@ -6,7 +6,7 @@ import '../../../domain/entities/dependency.dart';
 import '../../core/ui/ui.dart';
 
 class VadenDependenciesDialog extends StatefulWidget {
-  final Function(Dependency) onSave;
+  final Function(List<Dependency>) onSave;
   final VoidCallback onCancel;
   final List<Dependency> dependencies;
 
@@ -17,11 +17,11 @@ class VadenDependenciesDialog extends StatefulWidget {
     required this.dependencies,
   });
 
-  static Future<Dependency?> show(
+  static Future<List<Dependency>?> show(
     BuildContext context,
     List<Dependency> dependencies,
   ) async {
-    return await showDialog<Dependency>(
+    return await showDialog<List<Dependency>>(
       context: context,
       barrierDismissible: true,
       barrierColor: Colors.black.withValues(alpha: 0.5),
@@ -44,6 +44,7 @@ class VadenDependenciesDialog extends StatefulWidget {
 class _VadenDependenciesDialogState extends State<VadenDependenciesDialog> {
   var _currentCategory = 'Todos';
   String? _search;
+  final Set<Dependency> _selectedDependencies = {};
 
   List<String> _getUniqueCategories(List<Dependency> dependencies) {
     final categories = dependencies.map((dep) => dep.tag).toSet().toList();
@@ -65,6 +66,22 @@ class _VadenDependenciesDialogState extends State<VadenDependenciesDialog> {
           .toList();
     }
     return dependencies.where((dep) => dep.tag == _currentCategory).toList();
+  }
+
+  void _toggleDependency(Dependency dependency) {
+    setState(() {
+      if (_selectedDependencies.contains(dependency)) {
+        _selectedDependencies.remove(dependency);
+      } else {
+        _selectedDependencies.add(dependency);
+      }
+    });
+  }
+
+  void _submit() {
+    if (_selectedDependencies.isNotEmpty) {
+      widget.onSave(_selectedDependencies.toList());
+    }
   }
 
   @override
@@ -193,8 +210,8 @@ class _VadenDependenciesDialogState extends State<VadenDependenciesDialog> {
                                   title: dependency.name,
                                   subtitle: dependency.description,
                                   tag: dependency.tag,
-                                  isSelected: false,
-                                  onTap: () => widget.onSave(dependency),
+                                  isSelected: _selectedDependencies.contains(dependency),
+                                  onTap: () => _toggleDependency(dependency),
                                   maxLines: 3,
                                 ),
                               ))
@@ -202,24 +219,25 @@ class _VadenDependenciesDialogState extends State<VadenDependenciesDialog> {
                     ),
                   ),
                 ),
-                // child: ListView.separated(
-                //   shrinkWrap: true,
-                //   padding: const EdgeInsets.all(20),
-                //   itemCount: filteredDependencies.length,
-                //   separatorBuilder: (_, __) => const SizedBox(height: 12),
-                //   itemBuilder: (context, index) {
-                //     final dependency = filteredDependencies[index];
-
-                //     return VadenCard(
-                //       title: dependency.name,
-                //       subtitle: dependency.description,
-                //       tag: dependency.tag,
-                //       isSelected: false,
-                //       onTap: () => widget.onSave(dependency),
-                //       maxLines: 3,
-                //     );
-                //   },
-                // ),
+              ),
+              Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 16),
+                child: Row(
+                  mainAxisAlignment: MainAxisAlignment.end,
+                  children: [
+                    VadenButton(
+                        onPressed: widget.onCancel,
+                        label: 'cancel'.i18n(),
+                        width: 130,
+                        style: VadenButtonStyle.outlinedWhite),
+                    const SizedBox(width: 16),
+                    VadenButton(
+                      onPressed: _selectedDependencies.isNotEmpty ? _submit : null,
+                      label: 'confirm'.i18n(),
+                      width: 130,
+                    ),
+                  ],
+                ),
               ),
             ],
           ),


### PR DESCRIPTION
### 📄 Description

This PR updates the dependencies selection dialog to support multi-selection. Now, users can select multiple dependencies by clicking on the cards, and only confirm their selection by pressing the "Confirm" button. The dialog will only close and apply the selected dependencies after confirmation, improving the user experience for batch selection.

### 🔄 Changes Made

 - Refactored the dependencies dialog to allow multi-selection of dependencies.
 - Added visual feedback for selected dependencies.
 - Added "Confirm" and "Cancel" buttons to control dialog actions.
 - Updated the logic in the page to handle a list of selected dependencies.

⚠️ Tests have been added or updated. (I tested with fake data)
