### PR TITLE
Fix/async beans hotfix

### DIFF
--- a/vaden_class_scanner/lib/src/backend_builder.dart
+++ b/vaden_class_scanner/lib/src/backend_builder.dart
@@ -102,7 +102,6 @@ class VadenApp implements DartVadenApplication {
   Future<void> setup() async {
     final paths = <String, dynamic>{};
     final apis = <Api>[];
-    final asyncBeans = <Future<void> Function()>[];
     _injector.addLazySingleton<DSON>(_DSON.new);
 ''');
 
@@ -161,13 +160,7 @@ class VadenApp implements DartVadenApplication {
 
     aggregatedBuffer.writeln(
         '    _injector.addLazySingleton(OpenApiConfig.create(paths, apis).call);');
-    aggregatedBuffer.writeln('''
-
-    for (final asyncBean in asyncBeans) {
-      await asyncBean();
-    }
-
-''');
+        
     aggregatedBuffer.writeln('    _injector.commit();');
 
     aggregatedBuffer.writeln('$moduleRegisterBuffer');

--- a/vaden_class_scanner/lib/src/backend_builder.dart
+++ b/vaden_class_scanner/lib/src/backend_builder.dart
@@ -161,7 +161,6 @@ class VadenApp implements DartVadenApplication {
 
     aggregatedBuffer.writeln(
         '    _injector.addLazySingleton(OpenApiConfig.create(paths, apis).call);');
-    aggregatedBuffer.writeln('    _injector.commit();');
     aggregatedBuffer.writeln('''
 
     for (final asyncBean in asyncBeans) {
@@ -169,6 +168,7 @@ class VadenApp implements DartVadenApplication {
     }
 
 ''');
+    aggregatedBuffer.writeln('    _injector.commit();');
 
     aggregatedBuffer.writeln('$moduleRegisterBuffer');
     aggregatedBuffer.writeln('  }');

--- a/vaden_class_scanner/lib/src/setups/configuration_setup.dart
+++ b/vaden_class_scanner/lib/src/setups/configuration_setup.dart
@@ -25,12 +25,10 @@ String configurationSetup(ClassElement classElement) {
       }).join(', ');
 
       bodyBuffer.writeln('''
-asyncBeans.add(() async {
  _injector.commit();
 final result = await $instanceName.${method.name}($parametersCode);
  _injector.uncommit();
 _injector.addInstance(result);
-});
 
 ''');
     } else {

--- a/vaden_class_scanner/lib/src/setups/configuration_setup.dart
+++ b/vaden_class_scanner/lib/src/setups/configuration_setup.dart
@@ -26,9 +26,9 @@ String configurationSetup(ClassElement classElement) {
 
       bodyBuffer.writeln('''
  _injector.commit();
-final result = await $instanceName.${method.name}($parametersCode);
+final ${method.name} = await $instanceName.${method.name}($parametersCode);
  _injector.uncommit();
-_injector.addInstance(result);
+_injector.addInstance(${method.name});
 
 ''');
     } else {

--- a/vaden_class_scanner/lib/src/setups/configuration_setup.dart
+++ b/vaden_class_scanner/lib/src/setups/configuration_setup.dart
@@ -26,10 +26,10 @@ String configurationSetup(ClassElement classElement) {
 
       bodyBuffer.writeln('''
 asyncBeans.add(() async {
+ _injector.commit();
 final result = await $instanceName.${method.name}($parametersCode);
  _injector.uncommit();
 _injector.addInstance(result);
- _injector.commit();
 });
 
 ''');


### PR DESCRIPTION
### 📄 Description

Async beans were not being registered for use in repositories in time, the change adjusts the injector's commit/uncommit order to register asynchronous beans for use in repositories normally, previously it caused an injector unregistered error.

### 🔄 Changes Made

- Removed `List<AsyncBeans>` and adjustments in the `configuration_setup.dart` 

### ✅ Checklist

- [ ] Tests have been added or updated.  
- [ ] Documentation has been updated (if necessary).  
- [ ] Code review completed.

### 🔗 Related Issue

Resolves #<issue number>