### PR TITLE
fix: BindType lazySingleton not working

### DIFF
--- a/vaden_class_scanner/lib/src/backend_builder.dart
+++ b/vaden_class_scanner/lib/src/backend_builder.dart
@@ -254,7 +254,7 @@ class _DSON extends DSON {
         bindType = 'BindType.instance';
       } else if (scopeType == 'singleton') {
         bindType = 'BindType.singleton';
-      } else if (scopeType == 'lazySingleton') {
+      } else if (scopeType == 'lazysingleton') {
         bindType = 'BindType.lazySingleton';
       } else if (scopeType == 'factory') {
         bindType = 'BindType.factory';
@@ -276,7 +276,7 @@ class _DSON extends DSON {
       }
     } else if (scopeType == 'instance') {
       return '_injector.add(${classElement.name}.new);';
-    } else if (scopeType == 'lazySingleton') {
+    } else if (scopeType == 'lazysingleton') {
       return '_injector.addLazySingleton(${classElement.name}.new);';
     } else if (scopeType == 'singleton') {
       return '_injector.addSingleton(${classElement.name}.new);';

--- a/vaden_class_scanner/lib/src/backend_builder.dart
+++ b/vaden_class_scanner/lib/src/backend_builder.dart
@@ -242,7 +242,7 @@ class _DSON extends DSON {
     }
 
     String? scopeType;
-    String? bindType = 'BindType.singleton';
+    String? bindType = 'BindType.lazySingleton';
 
     // Check if the class is annotated with @Scope
     final scopeAnnotation = scopeChecker.firstAnnotationOf(classElement);


### PR DESCRIPTION
### 📄 Description

This PR adds support for the lazySingleton scope type in the dependency injection binding generation. Previously, even if lazySingleton was set as the scopeType, it was not being handled. With this change, it is now properly mapped to BindType.lazySingleton and the corresponding _injector.addLazySingleton(...) method is used.

### 🔄 Changes Made

- ✅ Added support for lazySingleton in BindType assignment logic.

### ✅ Checklist

- [X] Tests have been added or updated.  
- [X] Documentation has been updated (if necessary).  
- [ ] Code review completed.

### 🔗 Related Issue

Resolves #