### PR TITLE
fix: evitar registro de VadenMiddleware e VadenGuard por supertipo pa…

### DIFF
--- a/vaden_class_scanner/lib/src/setups/initial.dart
+++ b/vaden_class_scanner/lib/src/setups/initial.dart
@@ -209,15 +209,26 @@ String _componentRegister(
     final interfaceType =
         classElement.interfaces.firstOrNull ?? classElement.supertype;
     if (interfaceType != null && interfaceType.getDisplayString() != 'Object') {
-      return '''
+      // Don't register VadenMiddleware or VadenGuard by their supertype
+      // as multiple implementations would conflict
+      final supertypeDisplay = interfaceType.getDisplayString();
+      final isMiddlewareOrGuard =
+          supertypeDisplay == 'VadenMiddleware' ||
+          supertypeDisplay == 'VadenGuard';
+
+      if (!isMiddlewareOrGuard) {
+        return '''
       _injector.addBind(Bind.withClassName(
       constructor: ${classElement.name}.new,
       type: $bindType,
       className: '${interfaceType.getDisplayString()}',
     ));   
 ''';
+      }
     }
-  } else if (scopeType == 'instance') {
+  }
+
+  if (scopeType == 'instance') {
     return '_injector.add(${classElement.name}.new);';
   } else if (scopeType == 'lazysingleton') {
     return '_injector.addLazySingleton(${classElement.name}.new);';


### PR DESCRIPTION
### 📄 Description

Corrige o erro de registro duplicado no `AutoInjector` quando múltiplos middlewares ou guards são anotados com `@Component()`. O problema ocorria porque o class scanner tentava registrar todas as implementações usando o tipo da superclasse (`VadenMiddleware` ou `VadenGuard`), causando conflito.

A solução detecta quando uma classe estende `VadenMiddleware` ou `VadenGuard` e força o registro pelo tipo concreto, permitindo múltiplas implementações sem conflito.

### 🔄 Changes Made

- [x] Adiciona verificação no `_componentRegister` para identificar classes que estendem `VadenMiddleware` ou `VadenGuard`
- [x] Ignora o `registerWithInterfaceOrSuperType` para middlewares e guards, forçando registro pelo tipo concreto
- [x] Previne o erro "VadenMiddleware Class already exists on Injector" ao usar múltiplos middlewares globais

### ✅ Checklist

- [x] Tests have been added or updated. _(Testado com múltiplos middlewares no exemplo)_
- [ ] Documentation has been updated (if necessary). _(Não requer atualização de docs)_
- [x] Code review completed.

### 🔗 Related Issue

Resolves #113