### PR TITLE
fix: handle nullable types in @Query and @Param parsing

### DIFF
--- a/vaden_class_scanner/lib/src/backend_builder.dart
+++ b/vaden_class_scanner/lib/src/backend_builder.dart
@@ -134,16 +134,19 @@ class VadenApp implements DartVadenApplication {
 ''',
     );
 
-    aggregatedBuffer.writeln('''PType? _parse<PType>(String? value) {
+    aggregatedBuffer.writeln('''
+  Type _typeOf<T>() => T;
+
+  PType? _parse<PType>(String? value) {
     if (value == null) {
       return null;
     }
 
-    if(PType == int) {
+    if (PType == int || PType == _typeOf<int?>()) {
       return int.parse(value) as PType;
-    } else if(PType == double) {
+    } else if (PType == double || PType == _typeOf<double?>()) {
       return double.parse(value) as PType;
-    } else if(PType == bool) {
+    } else if (PType == bool || PType == _typeOf<bool?>()) {
       return bool.parse(value) as PType;
     } else {
       return value as PType;


### PR DESCRIPTION
### 📄 Description

Fixes the generated `_parse<PType>()` function to correctly handle nullable types (`int?`, `double?`, `bool?`). Previously, `_parse<int?>('42')` would fall through to the `else` branch and throw `type 'String' is not a subtype of type 'int?'` because `int? != int` in Dart's type system.

### 🔄 Changes Made

- [x] Added `_typeOf<T>()` helper to the generated code for runtime nullable type comparison
- [x] Extended `_parse` type checks to match both non-nullable and nullable variants (`int` and `int?`, `double` and `double?`, `bool` and `bool?`)

### ✅ Checklist

- [ ] Tests have been added or updated.
- [ ] Documentation has been updated (if necessary).
- [x] Code review completed.

### 🔗 Related Issue

Resolves #93